### PR TITLE
Add a bounds check for the response to avoid a panic when Zabbix misbehaves.

### DIFF
--- a/zabbix.go
+++ b/zabbix.go
@@ -240,6 +240,9 @@ func (s *Sender) Send(packet *Packet) (res Response, err error) {
 		return res, fmt.Errorf("reading the response (timeout=%v): %s", s.ReadTimeout, err)
 	}
 
+	if len(response) < 13 {
+		return res, fmt.Errorf("got truncated response [%+v] (len=%d)", response, len(response))
+	}
 	header := response[:5]
 	data := response[13:]
 


### PR DESCRIPTION
Hi, I found that Zabbix's responses can be truncated when it's pushed to its breaking point. This PR adds a bounds check to avoid a panic when indexing into a truncated response.

Thanks,
John